### PR TITLE
Strategy partial sale for fixed price

### DIFF
--- a/contracts/LooksRareExchange.sol
+++ b/contracts/LooksRareExchange.sol
@@ -75,6 +75,8 @@ contract LooksRareExchange is ILooksRareExchange, ReentrancyGuard, Ownable {
 
     mapping(address => uint256) public userMinOrderNonce;
     // maker => nonce => amount
+    // it is an executed amount
+    // amount == type(uint256).max means that an offer was cancelled or fully executed
     mapping(address => mapping(uint256 => uint256)) private _isUserOrderNonceExecutedOrCancelled;
 
     event CancelAllOrders(address indexed user, uint256 newMinNonce);
@@ -430,6 +432,16 @@ contract LooksRareExchange is ILooksRareExchange, ReentrancyGuard, Ownable {
      */
     function isUserOrderNonceExecutedOrCancelled(address user, uint256 orderNonce) external view returns (bool) {
         return _isUserOrderNonceExecutedOrCancelled[user][orderNonce] == type(uint256).max;
+    }
+
+    /**
+     * @notice Check an executed/used amount of an order.
+     * type(uint256).max means that the order was cancelled or fully used.
+     * @param user address of user
+     * @param orderNonce nonce of the order
+     */
+    function executedAmount(address user, uint256 orderNonce) external view returns (uint256) {
+        return _isUserOrderNonceExecutedOrCancelled[user][orderNonce];
     }
 
     /**

--- a/contracts/executionStrategies/StrategyPartialSaleForFixedPrice.sol
+++ b/contracts/executionStrategies/StrategyPartialSaleForFixedPrice.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {OrderTypes} from "../libraries/OrderTypes.sol";
+import {IExecutionStrategy} from "../interfaces/IExecutionStrategy.sol";
+
+/**
+ * @title StrategyStandardSaleForFixedPrice
+ * @notice Strategy that executes an order at a fixed price that
+ * can be taken either by a bid or an ask.
+ */
+contract StrategyPartialSaleForFixedPrice is IExecutionStrategy {
+    uint256 public immutable PROTOCOL_FEE;
+
+    /**
+     * @notice Constructor
+     * @param _protocolFee protocol fee (200 --> 2%, 400 --> 4%)
+     */
+    constructor(uint256 _protocolFee) {
+        PROTOCOL_FEE = _protocolFee;
+    }
+
+    /**
+     * @notice Check whether a taker ask order can be executed against a maker bid
+     * @param takerAsk taker ask order
+     * @param makerBid maker bid order
+     * @return (whether strategy can be executed, tokenId to execute, amount of tokens to execute)
+     */
+    function canExecuteTakerAsk(OrderTypes.TakerOrder calldata takerAsk, OrderTypes.MakerOrder calldata makerBid)
+        external
+        view
+        override
+        returns (
+            bool,
+            uint256,
+            uint256
+        )
+    {
+        uint256 takerAskAmount = abi.decode(takerAsk.params, (uint256));
+        return (
+            (_verifyPrice(takerAsk.price, takerAskAmount, makerBid.price, makerBid.amount) &&
+                (makerBid.tokenId == takerAsk.tokenId) &&
+                (makerBid.startTime <= block.timestamp) &&
+                (makerBid.endTime >= block.timestamp) &&
+                (takerAskAmount > 0) &&
+                (makerBid.amount >= takerAskAmount)),
+            makerBid.tokenId,
+            takerAskAmount
+        );
+    }
+
+    /**
+     * @notice Check whether a taker bid order can be executed against a maker ask
+     * @param takerBid taker bid order
+     * @param makerAsk maker ask order
+     * @return (whether strategy can be executed, tokenId to execute, amount of tokens to execute)
+     */
+    function canExecuteTakerBid(OrderTypes.TakerOrder calldata takerBid, OrderTypes.MakerOrder calldata makerAsk)
+        external
+        view
+        override
+        returns (
+            bool,
+            uint256,
+            uint256
+        )
+    {
+        uint256 takerBidAmount = abi.decode(takerBid.params, (uint256));
+        if (takerBidAmount == 0) {
+            return (false, makerAsk.tokenId, takerBidAmount);
+        }
+        return (
+            (_verifyPrice(makerAsk.price, makerAsk.amount, takerBid.price, takerBidAmount) &&
+                (makerAsk.tokenId == takerBid.tokenId) &&
+                (makerAsk.startTime <= block.timestamp) &&
+                (makerAsk.endTime >= block.timestamp) &&
+                (takerBidAmount > 0) &&
+                (makerAsk.amount >= takerBidAmount)),
+            makerAsk.tokenId,
+            takerBidAmount
+        );
+    }
+
+    /**
+     * @dev checks that askPrice/askAmount <= bidPrice/bidAmount
+     * which is askPrice * bidAmount <= bidPrice * askAmount
+     * note that these are uint256 * uint256 = uint512
+     * the function supports overflows and extreme values
+     * a lot of low level arithmetics
+     */
+    function _verifyPrice(
+        uint256 askPrice,
+        uint256 askAmount,
+        uint256 bidPrice,
+        uint256 bidAmount
+    ) private pure returns (bool result) {
+        // none operation oferflows
+        unchecked {
+            // low 128 bits
+            uint256 left = (askPrice & (2**128 - 1)) * (bidAmount & (2**128 - 1));
+            uint256 leftHigh = left >> 128;
+            left &= 2**128 - 1;
+            uint256 right = (bidPrice & (2**128 - 1)) * (askAmount & (2**128 - 1));
+            uint256 rightHigh = right >> 128;
+            right &= 2**128 - 1;
+            result = left <= right;
+
+            // middle 128 bits
+            left = leftHigh + (askPrice >> 128) * (bidAmount & (2**128 - 1));
+            leftHigh = left >> 128;
+            left &= 2**128 - 1;
+            left += (askPrice & (2**128 - 1)) * (bidAmount >> 128);
+            leftHigh += left >> 128;
+            left &= 2**128 - 1;
+            right = rightHigh + (bidPrice >> 128) * (askAmount & (2**128 - 1));
+            rightHigh = right >> 128;
+            right &= 2**128 - 1;
+            right += (bidPrice & (2**128 - 1)) * (askAmount >> 128);
+            rightHigh += right >> 128;
+            right &= 2**128 - 1;
+            result = left < right || (left == right && result);
+
+            // high 256 bits
+            left = leftHigh + (askPrice >> 128) * (bidAmount >> 128);
+            right = rightHigh + (bidPrice >> 128) * (askAmount >> 128);
+            result = left < right || (left == right && result);
+        }
+    }
+
+    /**
+     * @notice Return protocol fee for this strategy
+     * @return protocol fee
+     */
+    function viewProtocolFee() external view override returns (uint256) {
+        return PROTOCOL_FEE;
+    }
+}

--- a/contracts/executionStrategies/StrategyPartialSaleForFixedPrice.sol
+++ b/contracts/executionStrategies/StrategyPartialSaleForFixedPrice.sol
@@ -5,9 +5,10 @@ import {OrderTypes} from "../libraries/OrderTypes.sol";
 import {IExecutionStrategy} from "../interfaces/IExecutionStrategy.sol";
 
 /**
- * @title StrategyStandardSaleForFixedPrice
+ * @title StrategyPartialSaleForFixedPrice
  * @notice Strategy that executes an order at a fixed price that
  * can be taken either by a bid or an ask.
+ * Partial means that a taker can buy/sell a partial amount.
  */
 contract StrategyPartialSaleForFixedPrice is IExecutionStrategy {
     uint256 public immutable PROTOCOL_FEE;
@@ -66,9 +67,6 @@ contract StrategyPartialSaleForFixedPrice is IExecutionStrategy {
         )
     {
         uint256 takerBidAmount = abi.decode(takerBid.params, (uint256));
-        if (takerBidAmount == 0) {
-            return (false, makerAsk.tokenId, takerBidAmount);
-        }
         return (
             (_verifyPrice(makerAsk.price, makerAsk.amount, takerBid.price, takerBidAmount) &&
                 (makerAsk.tokenId == takerBid.tokenId) &&
@@ -85,7 +83,7 @@ contract StrategyPartialSaleForFixedPrice is IExecutionStrategy {
      * @dev checks that askPrice/askAmount <= bidPrice/bidAmount
      * which is askPrice * bidAmount <= bidPrice * askAmount
      * note that these are uint256 * uint256 = uint512
-     * the function supports overflows and extreme values
+     * the function supports uint256 overflows and extreme values
      * a lot of low level arithmetics
      */
     function _verifyPrice(

--- a/test/looksRareExchange.test.ts
+++ b/test/looksRareExchange.test.ts
@@ -74,6 +74,7 @@ describe("LooksRare Exchange", () => {
       royaltyFeeRegistry,
       royaltyFeeManager,
       royaltyFeeSetter,
+      ,
     ] = await setUp(admin, feeRecipient, royaltyCollector, standardProtocolFee, royaltyFeeLimit);
 
     await tokenSetUp(
@@ -2325,14 +2326,14 @@ describe("LooksRare Exchange", () => {
 
     it("ExecutionManager - View functions work as expected", async () => {
       const numberStrategies = await executionManager.viewCountWhitelistedStrategies();
-      assert.equal(numberStrategies.toString(), "5");
+      assert.equal(numberStrategies.toString(), "6");
 
       let tx = await executionManager.viewWhitelistedStrategies("0", "2");
       assert.equal(tx[0].length, 2);
       assert.deepEqual(BigNumber.from(tx[1].toString()), constants.Two);
 
       tx = await executionManager.viewWhitelistedStrategies("2", "100");
-      assert.equal(tx[0].length, 3);
+      assert.equal(tx[0].length, 4);
       assert.deepEqual(BigNumber.from(tx[1].toString()), BigNumber.from(numberStrategies.toString()));
     });
   });

--- a/test/strategyAnyItemFromCollectionForFixedPrice.test.ts
+++ b/test/strategyAnyItemFromCollectionForFixedPrice.test.ts
@@ -64,6 +64,7 @@ describe("Strategy - AnyItemFromCollectionForFixedPrice ('Collection orders')", 
       ,
       ,
       ,
+      ,
     ] = await setUp(admin, feeRecipient, royaltyCollector, standardProtocolFee, royaltyFeeLimit);
 
     await tokenSetUp(

--- a/test/strategyAnyItemInASetForAFixedPrice.test.ts
+++ b/test/strategyAnyItemInASetForAFixedPrice.test.ts
@@ -67,6 +67,7 @@ describe("Strategy - AnyItemInASetForFixedPrice ('Trait orders')", () => {
       ,
       ,
       ,
+      ,
     ] = await setUp(admin, feeRecipient, royaltyCollector, standardProtocolFee, royaltyFeeLimit);
 
     await tokenSetUp(

--- a/test/strategyDutchAuction.test.ts
+++ b/test/strategyDutchAuction.test.ts
@@ -65,6 +65,7 @@ describe("Strategy - Dutch Auction", () => {
       ,
       ,
       ,
+      ,
     ] = await setUp(admin, feeRecipient, royaltyCollector, standardProtocolFee, royaltyFeeLimit);
 
     await tokenSetUp(

--- a/test/strategyPartialSaleForFixedPrice.test.ts
+++ b/test/strategyPartialSaleForFixedPrice.test.ts
@@ -1,0 +1,728 @@
+import { assert, expect } from "chai";
+import { BigNumber, constants, Contract, utils } from "ethers";
+import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+import { MakerOrderWithSignature } from "./helpers/order-types";
+import { createMakerOrder, createTakerOrder } from "./helpers/order-helper";
+import { computeDomainSeparator, computeOrderHash } from "./helpers/signature-helper";
+import { setUp } from "./test-setup";
+import { tokenSetUp } from "./token-set-up";
+
+const { defaultAbiCoder, parseEther } = utils;
+
+describe("Strategy - PartialSaleForFixedPrice", () => {
+  // Mock contracts
+  let mockERC721: Contract;
+  let mockERC721WithRoyalty: Contract;
+  let mockERC1155: Contract;
+  let weth: Contract;
+
+  // Exchange contracts
+  let transferManagerERC721: Contract;
+  let transferManagerERC1155: Contract;
+  let looksRareExchange: Contract;
+
+  // Strategy contracts (used for this test file)
+  let strategyPartialSaleForFixedPrice: Contract;
+
+  // Other global variables
+  let standardProtocolFee: BigNumber;
+  let royaltyFeeLimit: BigNumber;
+  let accounts: SignerWithAddress[];
+  let admin: SignerWithAddress;
+  let feeRecipient: SignerWithAddress;
+  let royaltyCollector: SignerWithAddress;
+  let startTimeOrder: BigNumber;
+  let endTimeOrder: BigNumber;
+
+  beforeEach(async () => {
+    accounts = await ethers.getSigners();
+    admin = accounts[0];
+    feeRecipient = accounts[19];
+    royaltyCollector = accounts[15];
+    standardProtocolFee = BigNumber.from("200");
+    royaltyFeeLimit = BigNumber.from("9500"); // 95%
+    [
+      weth,
+      mockERC721,
+      mockERC1155,
+      ,
+      mockERC721WithRoyalty,
+      ,
+      ,
+      ,
+      transferManagerERC721,
+      transferManagerERC1155,
+      ,
+      looksRareExchange,
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      strategyPartialSaleForFixedPrice,
+    ] = await setUp(admin, feeRecipient, royaltyCollector, standardProtocolFee, royaltyFeeLimit);
+
+    await tokenSetUp(
+      accounts.slice(1, 10),
+      weth,
+      mockERC721,
+      mockERC721WithRoyalty,
+      mockERC1155,
+      looksRareExchange,
+      transferManagerERC721,
+      transferManagerERC1155
+    );
+
+    // Verify the domain separator is properly computed
+    assert.equal(await looksRareExchange.DOMAIN_SEPARATOR(), computeDomainSeparator(looksRareExchange.address));
+
+    // Set up defaults startTime/endTime (for orders)
+    startTimeOrder = BigNumber.from((await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp);
+    endTimeOrder = startTimeOrder.add(BigNumber.from("1000"));
+  });
+
+  describe("#1 - Regular sales", async () => {
+    it("Standard Order/ERC721/ETH only - MakerAsk order is matched by TakerBid order", async () => {
+      const makerAskUser = accounts[1];
+      const takerBidUser = accounts[2];
+
+      const makerAskOrder: MakerOrderWithSignature = await createMakerOrder({
+        isOrderAsk: true,
+        signer: makerAskUser.address,
+        collection: mockERC721.address,
+        price: parseEther("3"),
+        tokenId: constants.Zero,
+        amount: constants.One,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerAskUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerBidOrder = createTakerOrder({
+        isOrderAsk: false,
+        taker: takerBidUser.address,
+        price: parseEther("3"),
+        tokenId: constants.Zero,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      const tx = await looksRareExchange
+        .connect(takerBidUser)
+        .matchAskWithTakerBidUsingETHAndWETH(takerBidOrder, makerAskOrder, {
+          value: takerBidOrder.price,
+        });
+
+      await expect(tx)
+        .to.emit(looksRareExchange, "TakerBid")
+        .withArgs(
+          computeOrderHash(makerAskOrder),
+          makerAskOrder.nonce,
+          takerBidUser.address,
+          makerAskUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerAskOrder.currency,
+          makerAskOrder.collection,
+          makerAskOrder.tokenId,
+          makerAskOrder.amount,
+          takerBidOrder.price
+        );
+
+      assert.equal(await mockERC721.ownerOf("0"), takerBidUser.address);
+
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerAskUser.address, makerAskOrder.nonce)
+      );
+
+      // Orders that have been executed cannot be matched again
+      await expect(
+        looksRareExchange.connect(takerBidUser).matchAskWithTakerBidUsingETHAndWETH(takerBidOrder, makerAskOrder, {
+          value: takerBidOrder.price,
+        })
+      ).to.be.revertedWith("Order: Matching order expired");
+    });
+
+    it("Standard Order/ERC721/(ETH + WETH) - MakerAsk order is matched by TakerBid order", async () => {
+      const makerAskUser = accounts[1];
+      const takerBidUser = accounts[2];
+
+      const makerAskOrder: MakerOrderWithSignature = await createMakerOrder({
+        isOrderAsk: true,
+        signer: makerAskUser.address,
+        collection: mockERC721.address,
+        tokenId: constants.Zero,
+        price: parseEther("3"),
+        amount: constants.One,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerAskUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerBidOrder = createTakerOrder({
+        isOrderAsk: false,
+        taker: takerBidUser.address,
+        tokenId: constants.Zero,
+        price: parseEther("3"),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      // Order is worth 3 ETH; taker user splits it as 2 ETH + 1 WETH
+      const expectedBalanceInWETH = BigNumber.from((await weth.balanceOf(takerBidUser.address)).toString()).sub(
+        BigNumber.from(parseEther("1"))
+      );
+
+      const tx = await looksRareExchange
+        .connect(takerBidUser)
+        .matchAskWithTakerBidUsingETHAndWETH(takerBidOrder, makerAskOrder, {
+          value: parseEther("2"),
+        });
+
+      await expect(tx)
+        .to.emit(looksRareExchange, "TakerBid")
+        .withArgs(
+          computeOrderHash(makerAskOrder),
+          makerAskOrder.nonce,
+          takerBidUser.address,
+          makerAskUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerAskOrder.currency,
+          makerAskOrder.collection,
+          makerAskOrder.tokenId,
+          makerAskOrder.amount,
+          takerBidOrder.price
+        );
+
+      assert.equal(await mockERC721.ownerOf("0"), takerBidUser.address);
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerAskUser.address, makerAskOrder.nonce)
+      );
+
+      // Check balance of WETH is same as expected
+      assert.deepEqual(expectedBalanceInWETH, await weth.balanceOf(takerBidUser.address));
+    });
+
+    it("Standard Order/ERC1155/ETH only - MakerAsk order is matched by TakerBid order", async () => {
+      const makerAskUser = accounts[1];
+      const takerBidUser = accounts[2];
+
+      const makerAskOrder: MakerOrderWithSignature = await createMakerOrder({
+        isOrderAsk: true,
+        signer: makerAskUser.address,
+        collection: mockERC1155.address,
+        tokenId: constants.One,
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerAskUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerBidOrder = createTakerOrder({
+        isOrderAsk: false,
+        taker: takerBidUser.address,
+        tokenId: constants.One,
+        price: parseEther("3"),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.Two]),
+      });
+
+      const tx = await looksRareExchange
+        .connect(takerBidUser)
+        .matchAskWithTakerBidUsingETHAndWETH(takerBidOrder, makerAskOrder, {
+          value: takerBidOrder.price,
+        });
+
+      await expect(tx)
+        .to.emit(looksRareExchange, "TakerBid")
+        .withArgs(
+          computeOrderHash(makerAskOrder),
+          makerAskOrder.nonce,
+          takerBidUser.address,
+          makerAskUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerAskOrder.currency,
+          makerAskOrder.collection,
+          makerAskOrder.tokenId,
+          makerAskOrder.amount,
+          takerBidOrder.price
+        );
+
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerAskUser.address, makerAskOrder.nonce)
+      );
+
+      // User 2 had minted 2 tokenId=1 so he has 4
+      assert.equal((await mockERC1155.balanceOf(takerBidUser.address, "1")).toString(), "4");
+    });
+
+    it("Standard Order/ERC721/WETH only - MakerBid order is matched by TakerAsk order", async () => {
+      const makerBidUser = accounts[2];
+      const takerAskUser = accounts[1];
+
+      const makerBidOrder = await createMakerOrder({
+        isOrderAsk: false,
+        signer: makerBidUser.address,
+        collection: mockERC721.address,
+        tokenId: constants.Zero,
+        price: parseEther("3"),
+        amount: constants.One,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerBidUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerAskOrder = createTakerOrder({
+        isOrderAsk: true,
+        taker: takerAskUser.address,
+        tokenId: constants.Zero,
+        price: makerBidOrder.price,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      const tx = await looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder);
+      await expect(tx)
+        .to.emit(looksRareExchange, "TakerAsk")
+        .withArgs(
+          computeOrderHash(makerBidOrder),
+          makerBidOrder.nonce,
+          takerAskUser.address,
+          makerBidUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerBidOrder.currency,
+          makerBidOrder.collection,
+          takerAskOrder.tokenId,
+          makerBidOrder.amount,
+          makerBidOrder.price
+        );
+
+      assert.equal(await mockERC721.ownerOf("0"), makerBidUser.address);
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerBidUser.address, makerBidOrder.nonce)
+      );
+    });
+
+    it("Standard Order/ERC1155/WETH only - MakerBid order is matched by TakerAsk order", async () => {
+      const makerBidUser = accounts[1];
+      const takerAskUser = accounts[2];
+
+      const makerBidOrder = await createMakerOrder({
+        isOrderAsk: false,
+        signer: makerBidUser.address,
+        collection: mockERC1155.address,
+        tokenId: BigNumber.from("3"),
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerBidUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerAskOrder = createTakerOrder({
+        isOrderAsk: true,
+        taker: takerAskUser.address,
+        tokenId: BigNumber.from("3"),
+        price: makerBidOrder.price,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.Two]),
+      });
+
+      const tx = await looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder);
+      await expect(tx)
+        .to.emit(looksRareExchange, "TakerAsk")
+        .withArgs(
+          computeOrderHash(makerBidOrder),
+          makerBidOrder.nonce,
+          takerAskUser.address,
+          makerBidUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerBidOrder.currency,
+          makerBidOrder.collection,
+          takerAskOrder.tokenId,
+          makerBidOrder.amount,
+          makerBidOrder.price
+        );
+
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerBidUser.address, makerBidOrder.nonce)
+      );
+    });
+  });
+
+  describe("#2 - Partial sales", async () => {
+    it("Split Order/ERC1155/WETH only - MakerBid order is matched by two TakerAsk orders", async () => {
+      const makerBidUser = accounts[1];
+      const takerAskUser = accounts[2];
+
+      const makerBidOrder = await createMakerOrder({
+        isOrderAsk: false,
+        signer: makerBidUser.address,
+        collection: mockERC1155.address,
+        tokenId: BigNumber.from("3"),
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerBidUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerAskOrder = createTakerOrder({
+        isOrderAsk: true,
+        taker: takerAskUser.address,
+        tokenId: BigNumber.from("3"),
+        price: makerBidOrder.price.div(2),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      const tx1 = await looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder);
+      await expect(tx1)
+        .to.emit(looksRareExchange, "TakerAsk")
+        .withArgs(
+          computeOrderHash(makerBidOrder),
+          makerBidOrder.nonce,
+          takerAskUser.address,
+          makerBidUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerBidOrder.currency,
+          makerBidOrder.collection,
+          takerAskOrder.tokenId,
+          constants.One,
+          takerAskOrder.price
+        );
+
+      assert.isFalse(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerBidUser.address, makerBidOrder.nonce)
+      );
+
+      const tx2 = await looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder);
+      await expect(tx2)
+        .to.emit(looksRareExchange, "TakerAsk")
+        .withArgs(
+          computeOrderHash(makerBidOrder),
+          makerBidOrder.nonce,
+          takerAskUser.address,
+          makerBidUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerBidOrder.currency,
+          makerBidOrder.collection,
+          takerAskOrder.tokenId,
+          constants.One,
+          takerAskOrder.price
+        );
+
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerBidUser.address, makerBidOrder.nonce)
+      );
+    });
+
+    it("Split Order/ERC1155/WETH only - MakerBid order is not matched by excessive TakerAsk order", async () => {
+      const makerBidUser = accounts[1];
+      const takerAskUser = accounts[2];
+
+      const makerBidOrder = await createMakerOrder({
+        isOrderAsk: false,
+        signer: makerBidUser.address,
+        collection: mockERC1155.address,
+        tokenId: BigNumber.from("3"),
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerBidUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerAskOrder = createTakerOrder({
+        isOrderAsk: true,
+        taker: takerAskUser.address,
+        tokenId: BigNumber.from("3"),
+        price: makerBidOrder.price.div(2),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      const tx1 = await looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder);
+      await expect(tx1)
+        .to.emit(looksRareExchange, "TakerAsk")
+        .withArgs(
+          computeOrderHash(makerBidOrder),
+          makerBidOrder.nonce,
+          takerAskUser.address,
+          makerBidUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerBidOrder.currency,
+          makerBidOrder.collection,
+          takerAskOrder.tokenId,
+          constants.One,
+          takerAskOrder.price
+        );
+
+      assert.isFalse(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerBidUser.address, makerBidOrder.nonce)
+      );
+
+      takerAskOrder.params = defaultAbiCoder.encode(["uint256"], [constants.Two]);
+      await expect(
+        looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder)
+      ).to.be.revertedWith("Strategy: Excessive amount");
+    });
+
+    it("Split Order/ERC1155/WETH only - MakerBid order can be cancelled", async () => {
+      const makerBidUser = accounts[1];
+      const takerAskUser = accounts[2];
+
+      const makerBidOrder = await createMakerOrder({
+        isOrderAsk: false,
+        signer: makerBidUser.address,
+        collection: mockERC1155.address,
+        tokenId: BigNumber.from("3"),
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerBidUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerAskOrder = createTakerOrder({
+        isOrderAsk: true,
+        taker: takerAskUser.address,
+        tokenId: BigNumber.from("3"),
+        price: makerBidOrder.price.div(2),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      const tx1 = await looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder);
+      await expect(tx1)
+        .to.emit(looksRareExchange, "TakerAsk")
+        .withArgs(
+          computeOrderHash(makerBidOrder),
+          makerBidOrder.nonce,
+          takerAskUser.address,
+          makerBidUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerBidOrder.currency,
+          makerBidOrder.collection,
+          takerAskOrder.tokenId,
+          constants.One,
+          takerAskOrder.price
+        );
+
+      assert.isFalse(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerBidUser.address, makerBidOrder.nonce)
+      );
+
+      await looksRareExchange.connect(makerBidUser).cancelMultipleMakerOrders([makerBidOrder.nonce]);
+
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerBidUser.address, makerBidOrder.nonce)
+      );
+    });
+
+    it("Split Order/ERC1155/WETH only - MakerBid order is not matched by overpriced TakerAsk order", async () => {
+      const makerBidUser = accounts[1];
+      const takerAskUser = accounts[2];
+
+      const makerBidOrder = await createMakerOrder({
+        isOrderAsk: false,
+        signer: makerBidUser.address,
+        collection: mockERC1155.address,
+        tokenId: BigNumber.from("3"),
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerBidUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerAskOrder = createTakerOrder({
+        isOrderAsk: true,
+        taker: takerAskUser.address,
+        tokenId: BigNumber.from("3"),
+        price: makerBidOrder.price.div(2).add(1),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      await expect(
+        looksRareExchange.connect(takerAskUser).matchBidWithTakerAsk(takerAskOrder, makerBidOrder)
+      ).to.be.revertedWith("Strategy: Execution invalid");
+    });
+
+    it("Split Order/ERC1155/WETH only - MakerAsk order is matched by two TakerBid orders", async () => {
+      const makerAskUser = accounts[1];
+      const takerBidUser = accounts[2];
+
+      const makerAskOrder: MakerOrderWithSignature = await createMakerOrder({
+        isOrderAsk: true,
+        signer: makerAskUser.address,
+        collection: mockERC1155.address,
+        tokenId: constants.One,
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerAskUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerBidOrder = createTakerOrder({
+        isOrderAsk: false,
+        taker: takerBidUser.address,
+        tokenId: constants.One,
+        price: parseEther("3").div(2),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      const tx1 = await looksRareExchange.connect(takerBidUser).matchAskWithTakerBid(takerBidOrder, makerAskOrder);
+
+      await expect(tx1)
+        .to.emit(looksRareExchange, "TakerBid")
+        .withArgs(
+          computeOrderHash(makerAskOrder),
+          makerAskOrder.nonce,
+          takerBidUser.address,
+          makerAskUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerAskOrder.currency,
+          makerAskOrder.collection,
+          makerAskOrder.tokenId,
+          constants.One,
+          takerBidOrder.price
+        );
+
+      assert.isFalse(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerAskUser.address, makerAskOrder.nonce)
+      );
+
+      // User 2 had minted 2 tokenId=1 so he has 3
+      assert.equal((await mockERC1155.balanceOf(takerBidUser.address, "1")).toString(), "3");
+
+      const tx2 = await looksRareExchange.connect(takerBidUser).matchAskWithTakerBid(takerBidOrder, makerAskOrder);
+
+      await expect(tx2)
+        .to.emit(looksRareExchange, "TakerBid")
+        .withArgs(
+          computeOrderHash(makerAskOrder),
+          makerAskOrder.nonce,
+          takerBidUser.address,
+          makerAskUser.address,
+          strategyPartialSaleForFixedPrice.address,
+          makerAskOrder.currency,
+          makerAskOrder.collection,
+          makerAskOrder.tokenId,
+          constants.One,
+          takerBidOrder.price
+        );
+
+      assert.isTrue(
+        await looksRareExchange.isUserOrderNonceExecutedOrCancelled(makerAskUser.address, makerAskOrder.nonce)
+      );
+
+      // User 2 had minted 2 tokenId=1 so he has 4 now
+      assert.equal((await mockERC1155.balanceOf(takerBidUser.address, "1")).toString(), "4");
+    });
+
+    it("Split Order/ERC1155/WETH only - MakerAsk order is not matched by underpriced TakerBid order", async () => {
+      const makerAskUser = accounts[1];
+      const takerBidUser = accounts[2];
+
+      const makerAskOrder: MakerOrderWithSignature = await createMakerOrder({
+        isOrderAsk: true,
+        signer: makerAskUser.address,
+        collection: mockERC1155.address,
+        tokenId: constants.One,
+        price: parseEther("3"),
+        amount: constants.Two,
+        strategy: strategyPartialSaleForFixedPrice.address,
+        currency: weth.address,
+        nonce: constants.Zero,
+        startTime: startTimeOrder,
+        endTime: endTimeOrder,
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode([], []),
+        signerUser: makerAskUser,
+        verifyingContract: looksRareExchange.address,
+      });
+
+      const takerBidOrder = createTakerOrder({
+        isOrderAsk: false,
+        taker: takerBidUser.address,
+        tokenId: constants.One,
+        price: parseEther("3").div(2).sub(1),
+        minPercentageToAsk: constants.Zero,
+        params: defaultAbiCoder.encode(["uint256"], [constants.One]),
+      });
+
+      await expect(
+        looksRareExchange.connect(takerBidUser).matchAskWithTakerBid(takerBidOrder, makerAskOrder)
+      ).to.revertedWith("Strategy: Execution invalid");
+    });
+  });
+});

--- a/test/strategyPrivateSale.test.ts
+++ b/test/strategyPrivateSale.test.ts
@@ -64,6 +64,7 @@ describe("Strategy - PrivateSale", () => {
       ,
       ,
       ,
+      ,
     ] = await setUp(admin, feeRecipient, royaltyCollector, standardProtocolFee, royaltyFeeLimit);
 
     await tokenSetUp(

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -66,9 +66,13 @@ export async function setUp(
   const StrategyStandardSaleForFixedPrice = await ethers.getContractFactory("StrategyStandardSaleForFixedPrice");
   const strategyStandardSaleForFixedPrice = await StrategyStandardSaleForFixedPrice.deploy(standardProtocolFee);
   await strategyStandardSaleForFixedPrice.deployed();
+  const StrategyPartialSaleForFixedPrice = await ethers.getContractFactory("StrategyPartialSaleForFixedPrice");
+  const strategyPartialSaleForFixedPrice = await StrategyPartialSaleForFixedPrice.deploy(standardProtocolFee);
+  await strategyPartialSaleForFixedPrice.deployed();
 
   // Whitelist these five strategies
   await executionManager.connect(admin).addStrategy(strategyStandardSaleForFixedPrice.address);
+  await executionManager.connect(admin).addStrategy(strategyPartialSaleForFixedPrice.address);
   await executionManager.connect(admin).addStrategy(strategyAnyItemFromCollectionForFixedPrice.address);
   await executionManager.connect(admin).addStrategy(strategyAnyItemInASetForFixedPrice.address);
   await executionManager.connect(admin).addStrategy(strategyDutchAuction.address);
@@ -144,5 +148,6 @@ export async function setUp(
     royaltyFeeRegistry,
     royaltyFeeManager,
     royaltyFeeSetter,
+    strategyPartialSaleForFixedPrice,
   ];
 }


### PR DESCRIPTION
Some marketplaces, Rarible for instance, allow partial sales. I mean, if an offer is a sale of 5 items, you can buy 3 out of 5.
This PR delivers a strategy that do the same here. An offer is active until cancelled or the amount is in the offer is fully used.
When using a part of the offer, the price is not always divisible and rounding is required. Therefore the strategy checks this condition
```
askPrice * bidAmount <= bidPrice * askAmount
```
A little change in the LooksRare core contracts is required. Luckily it enables another strategies, for instance a dutch auction with large number of items to be bought one by one.
